### PR TITLE
Adds the missing *s* to the author URI.

### DIFF
--- a/hello.php
+++ b/hello.php
@@ -9,7 +9,7 @@ Plugin URI: https://wordpress.org/plugins/hello-dolly/
 Description: This is not just a plugin, it symbolizes the hope and enthusiasm of an entire generation summed up in two words sung most famously by Louis Armstrong: Hello, Dolly. When activated you will randomly see a lyric from <cite>Hello, Dolly</cite> in the upper right of your admin screen on every page.
 Author: Matt Mullenweg
 Version: 1.6
-Author URI: http://ma.tt/
+Author URI: https://ma.tt/
 */
 
 function hello_dolly_get_lyric() {


### PR DESCRIPTION
Adds the missing _s_ for secure protocol to the author URI.
